### PR TITLE
feat: return yup error as bad request message

### DIFF
--- a/generators/app/templates/src/middlewares/validator-middleware.js.template
+++ b/generators/app/templates/src/middlewares/validator-middleware.js.template
@@ -24,8 +24,10 @@ const validateReqBody = (req, _, next) => {
     const validator = getValidator(req.path, req.method);
     if (validator !== null) {
         Object.entries(validator).forEach(([location, schema]) => {
-            if (!schema.isValidSync(req[location])) {
-                return next(new BadRequestError());
+            try {
+                schema.validateSync(req[location]);
+            } catch (error) {
+                return next(new BadRequestError(error.message));
             }
         });
     }


### PR DESCRIPTION
## Problema

Quando ocorre um erro de validação do schema no yup o middleware de validação só retorna BadRequest. Isso dificulta na hora de debuggar a api, no caso de um terceiro utilizando ela.

## Solução

No lugar de usar `isValid` do yup utilza o `validate`. Ele joga um erro caso falhe alguma validação, caso tenha mensagem personalizada no yup ela é retornada aqui tbm.

## Possível melhoria

Retornar todos erros do schema na emsma requisição:

```js
    try {
        await schema.validateSync(data, { abortEarly: false });
    } catch (errors) {
        const schemaErrors = errors.inner.map(err => {
            return { field: err.path, message: err.message };
        });

        const formatedErrorsMessage = ....

        return next(new BadRequestError(formatedErrorsMessage));
    }
```