### PR TITLE
Fix original repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ $ yo blip-api-kates
 
 -   [Gabriel Santos](https://twitter.com/alitalvez)
 
-This generator was created based on original [oss generator](https://github.com/robertoachar/generator-blip-api-kates) created by [Roberto Achar](https://twitter.com/robertoachar) .
+This generator was created based on original [oss generator](https://github.com/robertoachar/generator-oss-project) created by [Roberto Achar](https://twitter.com/robertoachar) .
 
 ## License
 


### PR DESCRIPTION
The original repo's url is https://github.com/robertoachar/generator-oss-project, not https://github.com/robertoachar/generator-blip-api-kates.