### PR TITLE
fix: jest script to assure local execution

### DIFF
--- a/generators/app/templates/package.json.template
+++ b/generators/app/templates/package.json.template
@@ -11,8 +11,8 @@
         "src"
     ],
     "scripts": {
-        "coverage": "jest --colors --coverage",
-        "jest": "jest --colors --verbose",
+        "coverage": "npx jest --colors --coverage",
+        "jest": "npx jest --colors --verbose",
         "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
         "lint": "eslint 'src/**/*.js' 'test/**/*.js'",
         "start": "node src/server.js",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "generators"
     ],
     "scripts": {
-        "coverage": "jest --colors --coverage",
+        "coverage": "npx jest --colors --coverage",
         "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
-        "jest": "jest --colors --verbose",
+        "jest": "npx jest --colors --verbose",
         "lint": "eslint generators/**/*.js test/**/*.js",
         "test": "npm run lint && npm run jest"
     },


### PR DESCRIPTION
Using npx before jest command will assure that the command is executed through the local packages and not globally

